### PR TITLE
Feature/58635

### DIFF
--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -1,8 +1,14 @@
+
 import * as dotenv from 'dotenv';
-console.log(dotenv.config());
-const envVar = dotenv.config().parsed;
-console.log(envVar);
+const envVars = dotenv.config();
+
 const config = {
-  PORT: envVar.PORT,
+    port: envVars.parsed.PORT,
+    serviceUrl: envVars.parsed.SERVICE_URL
 };
+
+Object.freeze(
+    config
+);
+
 export default config;

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -1,0 +1,33 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import config from '../config/configurations';
+
+export class TraineeApi extends RESTDataSource {
+
+    constructor() {
+        super();
+        this.baseURL = `${config.serviceUrl}/api/trainee`;
+    }
+
+    willSendRequest(request) {
+        request.headers.set('authorization', this.context.token);
+    }
+
+    async getAll() {
+        return this.get('/getall');
+    }
+
+    createTrainee(user) {
+        const newTrainee = { ...user };
+        return this.post('/create', newTrainee);
+    }
+
+    updateTrainee(body) {
+        const traineeupdate = { ...body };
+        return this.put('/update', traineeupdate);
+    }
+
+    deleteTrainee(id) {
+        const path = '/remove/'.concat(id);
+        return this.delete(path);
+    }
+}

--- a/src/datasource/User.js
+++ b/src/datasource/User.js
@@ -1,0 +1,15 @@
+const { RESTDataSource } = require('apollo-datasource-rest');
+import  config  from '../config';
+
+export class UserApi extends RESTDataSource {
+
+    constructor() {
+        super();
+        this.baseURL = `${config.serviceUrl}/api/user`;
+    }
+
+    loginUser(payload) {
+        return this.post('/login', payload);
+    }
+
+}

--- a/src/datasource/inde.js
+++ b/src/datasource/inde.js
@@ -1,1 +1,2 @@
 export { default as UserApi } from '../datasource/User';
+export * from './Trainee';

--- a/src/datasource/inde.js
+++ b/src/datasource/inde.js
@@ -1,0 +1,1 @@
+export { default as UserApi } from '../datasource/User';

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -12,11 +12,13 @@ const typeDefs = mergeTypes(typesArray, { all: true });
 export default {
     resolvers: {
         Query: {
-            ...user.getMyProfile,
+            ...user.getMe,
             ...trainee.query,
         },
         Mutation: {
             ...trainee.mutation,
+            ...user.loginUser,
+
         },
         Subscription: {
             ...trainee.subscriptions,

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -5,8 +5,10 @@ type Query {
 
 type Mutation {
     createTrainee(user: CreateUserInput): User!
-    updateTrainee(id: ID!, role: String): User!
+    #updateTrainee(id: ID!, role: String): User!
+    updateTrainee(user: UpdateUserInput): User!
     deleteTrainee(id: ID!): User!
+    loginUser(payload: loginDataInput): String!
 }
 
 

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,19 +1,18 @@
 type Query {
-     getMyProfile: User!
-     getAll: [User]
+     getMe: User!
+     getAll: [getAllType]!
 }
 
 type Mutation {
     createTrainee(user: CreateUserInput): User!
-    #updateTrainee(id: ID!, role: String): User!
-    updateTrainee(user: UpdateUserInput): User!
-    deleteTrainee(id: ID!): User!
+    # updateTrainee(id: ID!, role: String): User!
+    updatedTrainee(id: ID!, dataToUpdate: UpdateUserInput): UpdatedUser!
+    deleteTrainee(id: ID!): DeletedUser!
     loginUser(payload: loginDataInput): String!
 }
 
-
 type Subscription {
     traineeAdded: User!
-    traineeUpdated: User!
+    traineeUpdated: UpdatedUser!
     traineeDeleted: ID!
 }

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -3,25 +3,32 @@ import instancePubSub from '../pubsub';
 import constant from '../../lib/constant';
 
 export default {
-    createTrainee: (parent,args,context)=>{
+    createTrainee: async (parent,args,context)=>{
         const {user} = args;
-        const newTrainee = userInstance.createUser(user);
-        instancePubSub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: newTrainee });
-        return newTrainee;
+        const { dataSources: { traineeApi } } = context;
+        const response = await traineeApi.createTrainee(user);
+       // console.log('response is', response);
+        instancePubSub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: response.data });
+        return response.data;
     },
 
-    updateTrainee: (parent , args ,context ) => {
-        const{ id , email, role } = args;
-        const updateTraine = userInstance.updateUser(user);
-        instancePubSub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updateTraine });
-         return updateTraine;
-
+    updatedTrainee: async (parent , args ,context ) => {
+      const { id, dataToUpdate } = args;
+    const { dataSources: { traineeApi } } = context;
+    const response = await traineeApi.updateTrainee({ id, dataToUpdate });
+    console.log(response);
+    instancePubSub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: response.data });
+      return response.data;
     },
-    
-    deleteTrainee:(parent,args,context) => {
+
+    deleteTrainee: async (parent,args,context) => {
         const { id } = args;
-        const deleteTraine = userInstance.delete(id);
-        instancePubSub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deleteTraine.id });
-        return deleteTraine;
+        const { dataSources: { traineeApi } } = context;
+        const response = await traineeApi.deleteTrainee(id);
+        console.log('for delete',response)
+        instancePubSub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: response });
+        return response;
+
     },
- }
+ };
+ 

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -2,4 +2,36 @@ input CreateUserInput {
     name: String!
     email: String!
     role: String!
+    password: String!
+    createdBy: String!
+}
+
+type getAllType {
+  _id: String
+  name: String
+  email: String
+  role: String
+  originalId: String
+  createdAt: String
+}
+
+input UpdateUserInput {
+    name: String
+    email: String
+    role: String
+    password: String
+    updatedBy: String
+}
+
+type UpdatedUser {
+    message: String
+    status: String
+    data: String
+
+}
+type DeletedUser {
+    message: String
+    status: String
+    data: ID
+
 }

--- a/src/modules/user/index.js
+++ b/src/modules/user/index.js
@@ -1,1 +1,2 @@
-export { default as getMyProfile } from './query';
+export { default as getProfile } from './query';
+export {  default as loginUser } from './mutation';

--- a/src/modules/user/mutation.js
+++ b/src/modules/user/mutation.js
@@ -1,0 +1,8 @@
+export default {
+    loginUser: async (parent, args, context) => {
+        const { payload: { email, password } } = args;
+        const { dataSources: { userApi } } = context;
+        const response  = await userApi.loginUser({ email, password });
+        return response.Data;
+    }
+}

--- a/src/modules/user/type.graphql
+++ b/src/modules/user/type.graphql
@@ -2,4 +2,10 @@ type User {
     id: ID!
     name: String!
     email: String!
+    role: String!
+}
+
+input loginDataInput {
+    email: String!
+    password: String!
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
-import { createServer } from 'http';
 import { ApolloServer } from 'apollo-server-express';
+import { createServer } from 'http';
+import UserApi from './datasource';
 
 class Server {
     constructor(config) {
@@ -26,6 +27,10 @@ class Server {
 
         this.Server = new ApolloServer({
             ...schema,
+            dataSources: () => {
+                const userApi = new UserApi();
+                return { userApi }; 
+            },
             onHealhCheck: () => new Promise((resolve) => {
                 resolve('Route is running');
             }),
@@ -41,7 +46,7 @@ class Server {
 
     run() {
         const { app, config: { port } } = this;
-       this.httpServer.listen(port, (err) => {
+        this.httpServer.listen(port, (err) => {
             if(err) {
                 console.log(err);
             }

--- a/src/server.js
+++ b/src/server.js
@@ -1,12 +1,12 @@
-import express from 'express';
+import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import { createServer } from 'http';
-import UserApi from './datasource';
+import { UserApi, TraineeApi } from './datasource';
 
 class Server {
     constructor(config) {
         this.config = config;
-        this.app = express();
+        this.app = Express();
     }
 
     bootstrap() {
@@ -29,7 +29,14 @@ class Server {
             ...schema,
             dataSources: () => {
                 const userApi = new UserApi();
-                return { userApi }; 
+                const traineeApi = new TraineeApi();
+                return { userApi, traineeApi }; 
+            },
+            context: ({ req }) => {
+                if (req) {
+                    return { token: req.headers.authorization  };
+                }
+                return {};
             },
             onHealhCheck: () => new Promise((resolve) => {
                 resolve('Route is running');


### PR DESCRIPTION
Add the trainee data source and add all the methods in there with respect to the available rest endpoints for trainees.
Update the schema of the entities with respect to the response of the above APIs.
Replace the mock implementation calls with actual API calls in your resolvers.
Steps

Add the context key in the Apollo Server instance, where you will get the token from the req header and return that token from there so that it is available in context.
Add a function in your data source willSendRequest where you will set the header of the request which you will get from the context.
Now as the last step make all changes according to the acceptance criteria.